### PR TITLE
PHPStorm: Configure PHP interpreter

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpInterpreters">
+    <interpreters>
+      <interpreter id="f58849c8-e0cd-4acc-973b-98da73eaafb1" name="php-cli" home="docker-compose://DATA" debugger_id="php.debugger.XDebug">
+        <remote_data INTERPRETER_PATH="php" HELPERS_PATH="/opt/.phpstorm_helpers" INITIALIZED="false" VALID="true" RUN_AS_ROOT_VIA_SUDO="false" DOCKER_ACCOUNT_NAME="Docker" DOCKER_COMPOSE_SERVICE_NAME="php-cli" DOCKER_REMOTE_PROJECT_PATH="/opt/project">
+          <type_data command="EXEC" />
+          <dockerComposeConfigurationPaths>
+            <item value="$PROJECT_DIR$/docker-compose.yml" />
+          </dockerComposeConfigurationPaths>
+          <envs />
+        </remote_data>
+      </interpreter>
+    </interpreters>
+  </component>
+  <component name="PhpUnit">
+    <phpunit_settings>
+      <phpunit_by_interpreter interpreter_id="f58849c8-e0cd-4acc-973b-98da73eaafb1" configuration_file_path="/data/phpunit.xml" custom_loader_path="/data/vendor/autoload.php" phpunit_phar_path="" use_configuration_file="true" />
+    </phpunit_settings>
+  </component>
+</project>


### PR DESCRIPTION
Configures Docker Compose PHP interpreter and phpunit to use said interpreter.

![image](https://user-images.githubusercontent.com/665110/184253937-a697ab9d-0e1a-4c5e-a67d-3d350240936f.png)
![image](https://user-images.githubusercontent.com/665110/184253952-2a49591b-7840-4183-85b1-104e436a037a.png)
