### PR TITLE
Switch default php for docker-compose and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Make commands should be executed on the host machine.
 * `umami` - installs Drupal with the demo_umami profile
 * `login` - gets a one-time login link
 * `switch` - switches branch, e.g.  `make BRANCH=9.3 switch`
-* `9.3|9.4|9.5|10.0|10.1` - provides a clean environment with the specified Drupal version
-* `php7.4|php8.0|php8.1` - starts with stack with the specified php version
+* `9.3|9.4|9.5|10.0|10.1|10.2|11.x` - provides a clean environment with the specified Drupal version
+* `php7.4|php8.0|php8.1|php8.2` - starts with stack with the specified php version
 
 ## PhpStorm configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   php-fpm:
     build:
       args:
-        BASE_IMAGE: skpr/php-fpm:${PHP_VERSION:-8.0}-dev-v2-latest
+        BASE_IMAGE: skpr/php-fpm:${PHP_VERSION:-8.2}-dev-v2-latest
         USERNAME: ${USERNAME:-skpr}
         UID: ${UID:-1000}
         GID: ${GID:-1000}
@@ -29,7 +29,7 @@ services:
   php-cli:
     build:
       args:
-        BASE_IMAGE: skpr/php-cli:${PHP_VERSION:-8.0}-dev-v2-latest
+        BASE_IMAGE: skpr/php-cli:${PHP_VERSION:-8.2}-dev-v2-latest
         USERNAME: ${USERNAME:-skpr}
         UID: ${UID:-1000}
         GID: ${GID:-1000}


### PR DESCRIPTION
The main adjustment is to to the docker-compose.yml. Without it `docker-compose up` will result in the following error when visiting `http://localhost:8080`:

```
Fatal error: Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 8.1.0". You are running 8.0.29. in /data/vendor/composer/platform_check.php on line 24
```

The default of `8.2` brings it inline with the Makefile: https://github.com/mstrelan/drupal-contrib/blob/main/Makefile#L10 