### PR TITLE
Remove premature references to 10.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '11.x']
+        drupal_version: ['9.5', '10.0', '10.1', '11.x']
 
     steps:
       - name: Create project

--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,6 @@ switch:
 	$(GIT_SWITCH) 10.1.x
 	make clean
 
-10.2: php8.2
-	$(GIT_SWITCH) 10.2.x
-	make clean
-
 11.x: php8.2
 	$(GIT_SWITCH) 11.x
 	make clean

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Make commands should be executed on the host machine.
 * `umami` - installs Drupal with the demo_umami profile
 * `login` - gets a one-time login link
 * `switch` - switches branch, e.g.  `make BRANCH=9.3 switch`
-* `9.3|9.4|9.5|10.0|10.1|10.2|11.x` - provides a clean environment with the specified Drupal version
+* `9.3|9.4|9.5|10.0|10.1|11.x` - provides a clean environment with the specified Drupal version
 * `php7.4|php8.0|php8.1|php8.2` - starts with stack with the specified php version
 
 ## PhpStorm configuration


### PR DESCRIPTION
As per https://www.drupal.org/node/3359338 there is no 10.2.x branch yet.