### PR TITLE
Use tmpfs for /var/lib/mysql

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ composer:
 	$(EXEC) composer install
 
 start: stop-php
-	PHP_VERSION=$(PHP_VERSION) $(DOCKER_COMPOSE) up --build -d
+	PHP_VERSION=$(PHP_VERSION) $(DOCKER_COMPOSE) up --build -d --wait
 
 stop:
 	$(DOCKER_COMPOSE) stop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,27 @@ services:
       - ./:/data
 
   mysql:
-    image: skpr/mtk-mysql-empty:latest
+    image: mysql:latest
     network_mode: service:nginx
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+      MYSQL_USER: local
+      MYSQL_PASSWORD: local
+      MYSQL_DATABASE: local
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: [ "CMD", "mysql", "-e", "USE local;" ]
+      interval: 1s
+      retries: 30
 
   selenium:
     image: ${SELENIUM_IMAGE:-selenium/standalone-chrome}
     network_mode: service:nginx
+
+volumes:
+  mysql-data:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs


### PR DESCRIPTION
Profiling on demo_umami install

| Path | Cache | Tmpfs mount | No mount |
| -- | -- | -- | -- |
| /admin/content | Cold | 799 ms | 3.5 s |
| /admin/content | Warm | 352 ms | 1.56 s |
| /admin/content/block | Cold | 1.30 s | 1.75 s |
| /admin/content/block | Warm | 183 ms | 183 ms |
| /admin/content/files | Cold | 1.70 s | 2.95 s |
| /admin/content/files | Warm | 204 ms | 232 ms |
| /admin/content/media | Cold | 1.74 s | 2.76 s |
| /admin/content/media | Warm | 1.35 s | 1.33 s |